### PR TITLE
Revert "Add boot image to unpack and repack with new kernel"

### DIFF
--- a/common/scripts/3_copy_kernel.sh
+++ b/common/scripts/3_copy_kernel.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-ls -l /usr/src/kernel/out/arch/arm64/boot/
-
 cp -v \
-  /usr/src/kernel/out/arch/arm64/boot/Image.gz \
+  /usr/src/kernel/out/arch/arm64/boot/Image.gz-dtb \
   /out/


### PR DESCRIPTION
This reverts commit 5229bfb18459bc8bae9cb30c63254155ace41285.

Fixes cawilliamson/android_build_astro_kernel#3.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>