### PR TITLE
Change kernel repo to PCLineageOS-Ports repo

### DIFF
--- a/common/scripts/1_fetch_kernel.sh
+++ b/common/scripts/1_fetch_kernel.sh
@@ -2,8 +2,8 @@
 
 # fetch kernel sources
 git clone \
-  -b ${1:-stock} \
-  https://github.com/cawilliamson/android_kernel_planetcomputing_astro.git \
+  -b ${1:-stock-android} \
+  https://github.com/PCLineageOS-Ports/android_kernel_planet_mt6873.git \
   /usr/src/kernel
 
 # git reset to specific git commit


### PR DESCRIPTION
This PR changes the kernel repo to the `PCLineageOS-Ports` GitHub organisation repo, as that has upstream patches, and works better with the Astro. It also means there's a place for kernel dev - and as you, @cawilliamson, are in that org, it makes sense.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
