### PR TITLE
Copy scripts inside Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,5 @@ RUN mkdir /opt/unpackbootimg && \
   git clone https://github.com/osm0sis/mkbootimg.git /opt/unpackbootimg && \
   cd /opt/unpackbootimg && \
   make
+
+COPY common /opt/common

--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,11 @@
 
 docker build -t buildkernel_astro .
 docker run \
-  -v $(pwd)/common:/common \
   -v $(pwd)/out:/out \
   buildkernel_astro \
   /bin/bash -c " \
-    /common/scripts/1_fetch_kernel.sh $1 $2 && \
-    /common/scripts/2_build_kernel.sh && \
-    /common/scripts/3_copy_kernel.sh && \
-    /common/scripts/4_fix_permissions.sh \
+    /opt/common/scripts/1_fetch_kernel.sh $1 $2 && \
+    /opt/common/scripts/2_build_kernel.sh && \
+    /opt/common/scripts/3_copy_kernel.sh && \
+    /opt/common/scripts/4_fix_permissions.sh \
   "

--- a/menuconfig.sh
+++ b/menuconfig.sh
@@ -2,10 +2,9 @@
 
 docker build -t buildkernel_astro .
 docker run -it \
-  -v $(pwd)/common:/common \
   -v $(pwd)/out:/out \
   buildkernel_astro \
   /bin/bash -c " \
-    /common/scripts/1_fetch_kernel.sh ${1} && \
-    /common/scripts/2_build_menuconfig.sh
+    /opt/common/scripts/1_fetch_kernel.sh ${1} && \
+    /opt/common/scripts/2_build_menuconfig.sh
   "


### PR DESCRIPTION
This means the scripts are bundled with the container, meaning it's reproducible, but they can be overridden with a bind volume mount.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>