### PR TITLE
Use packaged boot image tools, reduce Git breakage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt -y install \
   libncurses5 \
   libncurses-dev \
   libssl-dev \
+  mkbootimg \
   python-is-python3 \
   python2 \ 
   python3 \
@@ -36,8 +37,3 @@ RUN curl -L -o /var/tmp/clang.tar.gz https://android.googlesource.com/platform/p
   tar -xvpf /var/tmp/clang.tar.gz -C /opt && \
   ln -sf /opt/clang-${CLANG_VERSION} /opt/clang && \
   rm -f /var/tmp/clang.tar.gz
-
-RUN mkdir /opt/unpackbootimg && \
-  git clone https://github.com/osm0sis/mkbootimg.git /opt/unpackbootimg && \
-  cd /opt/unpackbootimg && \
-  make

--- a/common/scripts/3_copy_kernel.sh
+++ b/common/scripts/3_copy_kernel.sh
@@ -2,7 +2,7 @@
 
 # unpack boot.img
 mkdir -p /var/tmp/bootimg
-/opt/unpackbootimg/unpackbootimg -i /common/files/boot.img -o /var/tmp/bootimg
+/usr/bin/unpack_bootimg --boot_img /common/files/boot.img --out /var/tmp/bootimg
 
 # overwrite kernel
 cp -v \
@@ -10,7 +10,7 @@ cp -v \
   /var/tmp/bootimg/boot.img-kernel
 
 # repack boot.img
-/opt/unpackbootimg/mkbootimg \
+/usr/bin/mkbootimg \
   --base "$(cat /var/tmp/bootimg/boot.img-base)" \
   --board "$(cat /var/tmp/bootimg/boot.img-board)" \
   --cmdline "$(cat /var/tmp/bootimg/boot.img-cmdline)" \


### PR DESCRIPTION
This commit changes the Dockerfile and script to use the Debian
`mkbootimg` package instead of building from source.

This reduces Git-related breakage, and makes sure to use native
packages, which means we don't need to install compilers for the
container other than for kernel building.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
