### PR TITLE
Use pipes to download and extract clang and gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,10 @@ RUN apt -y install \
   xz-utils \
   zip
 
-RUN curl -L -o /var/tmp/gcc.tar.gz https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/pie-release.tar.gz && \
-  mkdir -p /opt/gcc && \
-  tar -xvpf /var/tmp/gcc.tar.gz -C /opt/gcc && \
-  rm -f /var/tmp/gcc.tar.gz
-
-RUN curl -L -o /var/tmp/clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/pie-release.tar.gz && \
-  tar -xvpf /var/tmp/clang.tar.gz -C /opt && \
-  ln -sf /opt/clang-${CLANG_VERSION} /opt/clang && \
-  rm -f /var/tmp/clang.tar.gz
+RUN mkdir -p /opt/gcc && \
+    curl -s "https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/refs/heads/pie-release.tar.gz" | tar xzf - -C /opt/gcc && \
+    curl -s "https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/pie-release.tar.gz" | tar xzf - -C /opt/ && \
+    ln -sf /opt/clang-${CLANG_VERSION} /opt/clang
 
 RUN mkdir /opt/unpackbootimg && \
   git clone https://github.com/osm0sis/mkbootimg.git /opt/unpackbootimg && \


### PR DESCRIPTION
To be more efficient, and use less disk I/O, this commit makes the curl commands download and extract their files in one line.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>